### PR TITLE
fixing rubocop errors

### DIFF
--- a/lib/crack.rb
+++ b/lib/crack.rb
@@ -9,7 +9,7 @@ filename.close
 
 e = Enigma.new
 
-output_file = File.open(ARGV[1],'w')
+output_file = File.open(ARGV[1], 'w')
 output_file.write(e.crack(input_text, ARGV[2].to_i))
 output_file.close
 

--- a/lib/key_generator.rb
+++ b/lib/key_generator.rb
@@ -1,5 +1,5 @@
 class KeyGenerator
   def create
-    rand(10000..99999).to_s
+    rand(100_00..999_99).to_s
   end
 end

--- a/test/cipher_test.rb
+++ b/test/cipher_test.rb
@@ -1,7 +1,7 @@
 require './test/test_helper.rb'
 require './lib/key_generator'
 require './lib/offset_calculator'
-# require './lib/enigma'
+require './lib/enigma'
 require './lib/cipher'
 
 class CipherTest < Minitest::Test
@@ -13,15 +13,15 @@ class CipherTest < Minitest::Test
   def test_encrypt_single
     cipher = Cipher.new
     rotations = [31, 38, 58, 71]
-    assert_equal "l", cipher.encrypt_single("t", 0, rotations)
+    assert_equal 'l', cipher.encrypt_single('t', 0, rotations)
   end
 
   def test_encrypt_message
     cipher = Cipher.new
-    key = "23567"
-    date = 160518
-    my_message = "this is so secret ..end.."
-    expected = "lg1l2h.3knql9b  l9r49mw43"
+    key = '23567'
+    date = 160_518
+    my_message = 'this is so secret ..end..'
+    expected = 'lg1l2h.3knql9b  l9r49mw43'
     actual = cipher.encrypt_message(my_message, key, date)
     assert_equal expected, actual
   end
@@ -29,30 +29,30 @@ class CipherTest < Minitest::Test
   def test_decrypt_single
     cipher = Cipher.new
     rotations = [-31, -38, -58, -71]
-    assert_equal "t", cipher.decrypt_single("l", 0, rotations)
+    assert_equal 't', cipher.decrypt_single('l', 0, rotations)
   end
 
   def test_decrypt_message
     cipher = Cipher.new
-    key = "23567"
-    date = 160518
-    actual = cipher.decrypt_message("lg1l2h.3knql9b  l9r49mw43", key, date)
-    expected = "this is so secret ..end.."
+    key = '23567'
+    date = 160_518
+    actual = cipher.decrypt_message('lg1l2h.3knql9b  l9r49mw43', key, date)
+    expected = 'this is so secret ..end..'
     assert_equal expected, actual
   end
 
   def test_can_crack_key
     cipher = Cipher.new
-    date = 160518
+    date = 160_518
     message = 'lg1l2h.3knql9b  l9r49mw43'
-    expected = 23567
+    expected = 235_67
     actual = cipher.crack_the_key(message, date)
     assert_equal expected, actual
   end
 
   def test_crack_works
     cipher = Cipher.new
-    date = 160518
+    date = 160_518
     expected = 'this is so secret ..end..'
     actual = cipher.crack('lg1l2h.3knql9b  l9r49mw43', date)
     assert_equal expected, actual

--- a/test/offset_calculator_test.rb
+++ b/test/offset_calculator_test.rb
@@ -9,8 +9,8 @@ class OffsetCalculatorTest < Minitest::Test
   end
 
   def test_it_stores_key_if_provided
-    offset = OffsetCalculator.new("12345", 150518)
-    assert_equal "12345", offset.key
+    offset = OffsetCalculator.new('12345', 150_518)
+    assert_equal '12345', offset.key
   end
 
   def test_it_creates_new_key_and_stores_it_if_no_key_provided
@@ -23,47 +23,47 @@ class OffsetCalculatorTest < Minitest::Test
   def test_it_reformats_date
     offset = OffsetCalculator.new(Date.today)
     expected = offset.reformat_date(offset.date)
-    actual = Date.today.strftime("%e%m%y").to_i
+    actual = Date.today.strftime('%e%m%y').to_i
     assert actual == expected
   end
 
   def test_if_date_already_formatted_it_does_nothing
-    offset = OffsetCalculator.new("12345", 150518)
+    offset = OffsetCalculator.new('12345', 150_518)
     expected = offset.reformat_date(offset.date)
-    actual = 150518
+    actual = 150_518
     assert actual == expected
   end
 
   def test_it_squares_the_date_and_changes_integer_to_string
-    offset = OffsetCalculator.new("12345", 150518)
-    assert_equal "22655668324", offset.square_the_date(offset.date)
+    offset = OffsetCalculator.new('12345', 150_518)
+    assert_equal '22655668324', offset.square_the_date(offset.date)
   end
 
   def test_slice_into_four
-    offset = OffsetCalculator.new(123456)
-    date_squared = "2633537124"
+    offset = OffsetCalculator.new(123_456)
+    date_squared = '2633537124'
     actual = offset.slice_into_four(date_squared)
-    expected = "7124"
+    expected = '7124'
     assert_equal expected, actual
   end
 
   def test_it_turns_four_digit_string_into_array
     offset = OffsetCalculator.new(Date.today)
-    four_numbers = "7124"
+    four_numbers = '7124'
     actual = offset.string_to_int_array(four_numbers)
     expected = [7, 1, 2, 4]
     assert_equal expected, actual
   end
 
   def test_it_adds_date_array_and_key_array
-    offset = OffsetCalculator.new("12345", 150518)
+    offset = OffsetCalculator.new('12345', 150_518)
     key_array = [12, 23, 34, 45]
     date_array = [8, 3, 2, 4]
     assert_equal [20, 26, 36, 49], offset.add_arrays(key_array, date_array)
   end
 
   def test_it_creates_rotations_array
-    offset = OffsetCalculator.new("12345", 150518)
+    offset = OffsetCalculator.new('12345', 150_518)
     assert_equal [20, 26, 36, 49], offset.create
   end
 end


### PR DESCRIPTION
Fixed all rubocop errors with the exception of one line that was over 80 characters long in the crack.rb file.